### PR TITLE
public key is now copied with SFTP; multiple commands are run on PTY …

### DIFF
--- a/ide/ide.go
+++ b/ide/ide.go
@@ -4,6 +4,6 @@ type IDE struct {
 	Identifier string
 	Name       string
 	Aliases    []string
-	OnOpen     func(hostPattern, folderPath string) error
+	OnOpen     func(hostPattern, folderPath, additionalInfo string) error
 	OnTestPath func() (string, bool)
 }

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 
@@ -121,13 +120,19 @@ func entry(ctx context.Context, cliCmd *cli.Command) error {
 		password = &parsedPw
 	}
 
-	config, err := ssh.CreateClientConfig(parsedArgs[sshHostFlag], parsedArgs[sshPortFlag], parsedArgs[sshUserFlag], password)
-	if err != nil {
+	onLaunchIDE := func(useIdentityKey bool, folderPath string) error {
+		return openWithIDE(&ide, folderPath, password, useIdentityKey)
+	}
+
+	err := ssh.SetupSSH(parsedArgs[sshHostFlag], parsedArgs[sshPortFlag], parsedArgs[sshUserFlag], password, onLaunchIDE)
+
+	var configErr ssh.ConfigErr
+	if errors.As(err, &configErr) {
 		_ = cli.ShowSubcommandHelp(cliCmd)
 		return err
 	}
 
-	return openWithIDE(&ide, config)
+	return err
 }
 
 func usageTextForCommand(command string) string {
@@ -202,31 +207,7 @@ func autoChooseIDE() (ide.IDE, error) {
 	return ide.IDE{}, fmt.Errorf("IDE could not be detected automatically, please specify the IDE explicitly instead of using the '%s' subcommand", autoCommand)
 }
 
-func setupSSH(sshConfigEntry *ssh.ConfigEntry) (string, bool, error) {
-	useIdentityKey, folder, err := ssh.SetupRemoteConfig(sshConfigEntry)
-	if err != nil {
-		var opErr *net.OpError
-		if errors.As(err, &opErr) && opErr.Op == "dial" {
-			return "", useIdentityKey, fmt.Errorf("dial remote host: please check the SSH arguments and make sure the remote host is reachable")
-		}
-		logger.Warn(err)
-	}
-
-	if err := ssh.SetupClientConfig(sshConfigEntry, useIdentityKey); err != nil {
-		return "", useIdentityKey, err
-	} else {
-		logger.Success("Your SSH config is set up!")
-	}
-
-	return folder, useIdentityKey, nil
-}
-
-func openWithIDE(ide *ide.IDE, config *ssh.ConfigEntry) error {
-	folder, usingKey, err := setupSSH(config)
-	if err != nil {
-		return err
-	}
-
+func openWithIDE(ide *ide.IDE, folder string, password *string, usingKey bool) error {
 	if folder == "" {
 		confirm, err := logger.Confirm(
 			"Source code location is unknown.\nWould you like to use the root directory and proceed?",
@@ -239,8 +220,8 @@ func openWithIDE(ide *ide.IDE, config *ssh.ConfigEntry) error {
 	}
 
 	var additionalInfo string
-	if !usingKey && config.Password != nil {
-		additionalInfo = fmt.Sprintf("Your password for SSH connection:\n\n%s\n\ncopy this into the password field of the opening window", *config.Password)
+	if !usingKey && password != nil {
+		additionalInfo = fmt.Sprintf("Your password for SSH connection:\n\n%s\n\ncopy this into the password field of the opening window", *password)
 	}
 
 	return ide.OnOpen(ssh.BitriseHostPattern, folder, additionalInfo)

--- a/ssh/remote_file_operations.go
+++ b/ssh/remote_file_operations.go
@@ -1,0 +1,132 @@
+package ssh
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/sftp"
+	cryptoSSH "golang.org/x/crypto/ssh"
+)
+
+type copyItem struct {
+	Content     string
+	RemotePath  string
+	Replace     *map[string]string
+	Append      bool
+	NoDuplicate bool
+}
+
+func fileExistsSFTP(client *sftp.Client, item *copyItem) (bool, error) {
+	stat, err := client.Stat(item.RemotePath)
+	if err == nil {
+		// File exists
+		if !item.Append {
+			return true, fmt.Errorf("remote file already exists: %s", item.RemotePath)
+		}
+		if item.NoDuplicate {
+			file, err := client.Open(item.RemotePath)
+			if err != nil {
+				return true, fmt.Errorf("open remote file: %w", err)
+			}
+			defer file.Close()
+
+			fileContent, err := io.ReadAll(file)
+			if err != nil {
+				return true, fmt.Errorf("read remote file content: %w", err)
+			}
+
+			if strings.Contains(string(fileContent), item.Content) {
+				return true, fmt.Errorf("remote file already contains the content")
+			}
+		}
+		return true, nil
+	}
+	if !os.IsNotExist(err) {
+		return false, fmt.Errorf("check file existence: %w", err)
+	}
+	return stat != nil, nil
+}
+
+func copyItemSFTP(client *cryptoSSH.Client, item *copyItem) error {
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return fmt.Errorf("create SFTP client: %w", err)
+	}
+	defer sftpClient.Close()
+
+	exists, err := fileExistsSFTP(sftpClient, item)
+	if err != nil {
+		return fmt.Errorf("copy to remote: %w", err)
+	}
+
+	if err := sftpClient.MkdirAll(filepath.Dir(item.RemotePath)); err != nil {
+		return fmt.Errorf("create remote directories: %w", err)
+	}
+
+	var dstFile *sftp.File
+	if exists && item.Append {
+		dstFile, err = sftpClient.OpenFile(item.RemotePath, os.O_APPEND|os.O_WRONLY)
+		if err != nil {
+			return fmt.Errorf("open file for appending: %w", err)
+		}
+	} else {
+		dstFile, err = sftpClient.Create(item.RemotePath)
+		if err != nil {
+			return fmt.Errorf("create file: %w", err)
+		}
+	}
+	defer dstFile.Close()
+
+	// Replace placeholders in content
+	modifiedContent := item.Content
+	if item.Replace != nil {
+		for key, value := range *item.Replace {
+			modifiedContent = strings.ReplaceAll(modifiedContent, key, value)
+		}
+	}
+
+	if _, err := dstFile.Write([]byte(modifiedContent)); err != nil {
+		return fmt.Errorf("write destination file: %w", err)
+	}
+
+	return nil
+}
+
+func fileExistsSSH(client *cryptoSSH.Client, item *copyItem) (bool, error) {
+	var result map[string]string
+	cmd := fmt.Sprintf("test -f %q && echo exists || echo missing", item.RemotePath)
+	if err := runWithPty(client, &[]string{"cd ~", cmd}, "", &result); err != nil {
+		return false, fmt.Errorf("check file existence: %w", err)
+	}
+
+	exists := strings.TrimSpace(result[cmd]) == "exists"
+	return exists, nil
+}
+
+func copyItemSSH(client *cryptoSSH.Client, item *copyItem) error {
+	exists, err := fileExistsSSH(client, item)
+	if err != nil {
+		return fmt.Errorf("check remote file: %w", err)
+	}
+
+	cmd := fmt.Sprintf("mkdir -p %q", filepath.Dir(item.RemotePath))
+	if err := runWithPty(client, &[]string{"cd ~", cmd}, "", nil); err != nil {
+		return fmt.Errorf("create remote directories: %w", err)
+	}
+
+	var cmdWrite string
+	if exists && item.Append {
+		cmdWrite = fmt.Sprintf("echo %q >> %q", item.Content, item.RemotePath)
+	} else {
+		cmdWrite = fmt.Sprintf("echo %q > %q", item.Content, item.RemotePath)
+	}
+
+	if err := runWithPty(client, &[]string{"cd ~", cmdWrite}, "", nil); err != nil {
+		return fmt.Errorf("write to remote file: %w", err)
+	}
+
+	return nil
+}

--- a/ssh/run_with_pty.go
+++ b/ssh/run_with_pty.go
@@ -49,7 +49,7 @@ func runWithPty(client *cryptoSSH.Client, commands *[]string, commandPrefix stri
 		} else {
 			formattedCommand = fmt.Sprintf("%s\r", command)
 		}
-		jointCommands += commandPrefix + formattedCommand
+		jointCommands = fmt.Sprintf("%s%s%s", jointCommands, commandPrefix, formattedCommand)
 	}
 
 	// Session woould wait for the last command to finish, so we need to exit the shell

--- a/ssh/run_with_pty.go
+++ b/ssh/run_with_pty.go
@@ -1,0 +1,92 @@
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	cryptoSSH "golang.org/x/crypto/ssh"
+)
+
+// runWithPty runs the given commands on the remote server using a pseudo terminal.
+// It takes an SSH client, a slice of commands, a command prefix, and a result map to store the output.
+// The function returns an error if any step fails.
+func runWithPty(client *cryptoSSH.Client, commands *[]string, commandPrefix string, resultMap *map[string]string) error {
+	session, err := createSSHSession(client)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	// Request a pseudo terminal
+	session.RequestPty("xterm", 80, 40, cryptoSSH.TerminalModes{})
+
+	// Save pipe for commands later
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("get stdin pipe: %w", err)
+	}
+
+	// Start remote shell
+	if err := session.Shell(); err != nil {
+		return fmt.Errorf("start shell: %w", err)
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+	session.Stderr = &stderrBuf
+
+	// Commands will be given in a single string, separated by carriage return
+	var jointCommands string
+	for _, command := range *commands {
+		// Format the command to be able to extract the output later
+		// Output will be in the format (prefix not included): [command=output]
+		var formattedCommand string
+		if resultMap != nil {
+			formattedCommand = fmt.Sprintf("%s | awk '{print \"[%s=\"$0\"]\"}'\r", command, command)
+		} else {
+			formattedCommand = fmt.Sprintf("%s\r", command)
+		}
+		jointCommands += commandPrefix + formattedCommand
+	}
+
+	// Session woould wait for the last command to finish, so we need to exit the shell
+	if _, err := fmt.Fprintf(stdin, "%sexit\r", jointCommands); err != nil {
+		return fmt.Errorf("send command: %w", err)
+	}
+
+	// Wait till exit
+	if err := session.Wait(); err != nil {
+		return fmt.Errorf("wait for session: %w", err)
+	}
+
+	// Check for errors
+	if stderrBuf.Len() > 0 {
+		return fmt.Errorf("stderr: %s", stderrBuf.String())
+	}
+
+	if resultMap == nil {
+		return nil
+	}
+
+	if *resultMap == nil {
+		*resultMap = make(map[string]string)
+	}
+
+	// Extract the output
+	output := stdoutBuf.String()
+	for _, command := range *commands {
+		prefix := fmt.Sprintf("[%s=", command)
+		startIndex := strings.LastIndex(output, prefix)
+		if startIndex != -1 {
+			startIndex += len(prefix)
+			endIndex := strings.Index(output[startIndex:], "]")
+			if endIndex != -1 {
+				result := output[startIndex : startIndex+endIndex]
+				(*resultMap)[command] = result
+			}
+		}
+	}
+
+	return nil
+}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -274,7 +274,7 @@ func bitriseConfigPath() string {
 	return filepath.Join(getHomeDir(), ".bitrise", "remote-access", "ssh_config")
 }
 
-func ensureClientKeyOnRemote(client *cryptoSSH.Client, configEntry *configEntry) error {
+func ensureClientKeyOnRemote(client *cryptoSSH.Client) error {
 	keyPath := filepath.Join(getHomeDir(), ".ssh", sshKeyName)
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", keyPath, "-C", "Bitrise remote access key", "-N", "")
@@ -429,7 +429,7 @@ func setupRemoteConfig(configEntry *configEntry, onRemoteDetected func(bool), on
 		onRemoteDetected(useIdentiyConfig)
 
 		logger.Info("Ensuring SSH key is available...")
-		if err := ensureClientKeyOnRemote(client, configEntry); err != nil {
+		if err := ensureClientKeyOnRemote(client); err != nil {
 			if errors.Unwrap(err) == ErrRemoteFileExists {
 				logger.Info("SSH key already ensured")
 			} else {

--- a/vscode/vscode.go
+++ b/vscode/vscode.go
@@ -27,7 +27,7 @@ var IdeData = ide.IDE{
 	OnOpen:     openInVSCode,
 	OnTestPath: isVSCodeInstalled}
 
-func openInVSCode(hostPattern, folderPath string) error {
+func openInVSCode(hostPattern, folderPath, additionalInfo string) error {
 	codePath, installed := isVSCodeInstalled()
 	if !installed {
 		logger.Infof(`
@@ -46,7 +46,12 @@ Please visit the following sites for more info:
 		return fmt.Errorf("%s does not have the necessary extensions installed", ideName)
 	}
 
-	logger.Infof("Opening %s...", folderPath)
+	if additionalInfo != "" {
+		header := fmt.Sprintf("Opening %s", ideName)
+		logger.PrintFormattedOutput(header, fmt.Sprintf("Source code location:\n\n%s\n\n%s", folderPath, additionalInfo))
+	} else {
+		logger.Infof("Opening %s...", folderPath)
+	}
 
 	openPath := fmt.Sprintf("--folder-uri=vscode-remote://ssh-remote+%s%s/", hostPattern, folderPath)
 


### PR DESCRIPTION
- Public key now will be copied with SFTP instead of `ssh-copy-id` command resulting in faster execution (-2.5s approximately)
- When multiple commands needed to be run they can now in one session using PTY resulting in faster execution
- PTY can also be used to extract environment variables from Linux remotes
